### PR TITLE
Separate task failures

### DIFF
--- a/LLM Testing/Code-Testing/src/main/java/FailureFileWriter.java
+++ b/LLM Testing/Code-Testing/src/main/java/FailureFileWriter.java
@@ -25,7 +25,7 @@ public class FailureFileWriter {
         List<String> assertionMessages = new ArrayList<>(providedAsserts);
         assertionMessages.addAll(hiddenAsserts);
 
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(fileName))) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter("src/main/resources/" + fileName))) {
             for (int i = 0; i < failedTests.size(); i++) {
                 String failedTest = failedTests.get(i);
                 String assertionMessage = assertionMessages.get(i);

--- a/LLM Testing/Code-Testing/src/main/java/FailureFileWriter.java
+++ b/LLM Testing/Code-Testing/src/main/java/FailureFileWriter.java
@@ -1,20 +1,29 @@
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class FailureFileWriter {
-    public static void writeFailuresToFile(List<String> failedTests, List<String> assertionMessages, String type) {
-        if (failedTests.size() != assertionMessages.size()) {
+    public static void writeFailuresToFile(List<String> failedProvidedTests, List<String> failedHiddenTests, List<String> providedAsserts, List<String> hiddenAsserts, String task) {
+        if ((failedProvidedTests.size() != providedAsserts.size()) || (failedHiddenTests.size() != hiddenAsserts.size())) {
             throw new IllegalArgumentException("Failed tests and assertion messages must have the same size.");
         }
 
         String fileName = "";
-        if (type.equals("PROVIDED")) {
-            fileName = "provided_failures.txt";
-        } else if (type.equals("HIDDEN")) {
-            fileName = "hidden_failures.txt";
+        if (task.equals("T1")) {
+            fileName = "t1_failures.txt";
+        } else if (task.equals("T2")) {
+            fileName = "t2_failures.txt";
+        } else if (task.equals("T3")) {
+            fileName = "t3_failures.txt";
         }
+
+        // Combining provided and hidden lists
+        List<String> failedTests = new ArrayList<>(failedProvidedTests);
+        failedTests.addAll(failedHiddenTests);
+        List<String> assertionMessages = new ArrayList<>(providedAsserts);
+        assertionMessages.addAll(hiddenAsserts);
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(fileName))) {
             for (int i = 0; i < failedTests.size(); i++) {

--- a/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
+++ b/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
@@ -37,10 +37,16 @@ public class ShellScriptRunner {
             Map<String, String> t1ProvidedFailureMessages = providedFailureMessages.get(0);
             Map<String, String> t2ProvidedFailureMessages = providedFailureMessages.get(1);
             Map<String, String> t3ProvidedFailureMessages = providedFailureMessages.get(2);
-//            List<String> providedTestNames = new ArrayList<>(providedFailureMessages.keySet());
-//            List<String> providedAsserts = new ArrayList<>(providedFailureMessages.values());
-//            List<String> failedProvidedTests = TestFinder.extractTestMethods(providedTestNames, "PROVIDED");
-//            FailureFileWriter.writeFailuresToFile(failedProvidedTests, providedAsserts, "PROVIDED");
+
+            List<String> t1ProvidedTestNames = new ArrayList<>(t1ProvidedFailureMessages.keySet());
+            List<String> t1ProvidedAsserts = new ArrayList<>(t1ProvidedFailureMessages.values());
+            List<String> t1FailedProvidedTests = TestFinder.extractTestMethods(t1ProvidedTestNames, "PROVIDED");
+            List<String> t2ProvidedTestNames = new ArrayList<>(t2ProvidedFailureMessages.keySet());
+            List<String> t2ProvidedAsserts = new ArrayList<>(t2ProvidedFailureMessages.values());
+            List<String> t2FailedProvidedTests = TestFinder.extractTestMethods(t2ProvidedTestNames, "PROVIDED");
+            List<String> t3ProvidedTestNames = new ArrayList<>(t3ProvidedFailureMessages.keySet());
+            List<String> t3ProvidedAsserts = new ArrayList<>(t3ProvidedFailureMessages.values());
+            List<String> t3FailedProvidedTests = TestFinder.extractTestMethods(t3ProvidedTestNames, "PROVIDED");
 
             // Running Hidden Tests
             runCommand(repositoryDirectory, "CLEAR_TESTS");
@@ -59,12 +65,21 @@ public class ShellScriptRunner {
             Map<String, String> t1HiddenFailureMessages = hiddenFailureMessages.get(0);
             Map<String, String> t2HiddenFailureMessages = hiddenFailureMessages.get(1);
             Map<String, String> t3HiddenFailureMessages = hiddenFailureMessages.get(2);
-//            List<String> hiddenTestNames = new ArrayList<>(hiddenFailureMessages.keySet());
-//            List<String> hiddenAsserts = new ArrayList<>(hiddenFailureMessages.values());
-//            List<String> failedHiddenTests = TestFinder.extractTestMethods(hiddenTestNames, "HIDDEN");
-//            FailureFileWriter.writeFailuresToFile(failedHiddenTests, hiddenAsserts, "HIDDEN");
+
+            List<String> t1HiddenTestNames = new ArrayList<>(t1HiddenFailureMessages.keySet());
+            List<String> t1HiddenAsserts = new ArrayList<>(t1HiddenFailureMessages.values());
+            List<String> t1FailedHiddenTests = TestFinder.extractTestMethods(t1HiddenTestNames, "HIDDEN");
+            List<String> t2HiddenTestNames = new ArrayList<>(t2HiddenFailureMessages.keySet());
+            List<String> t2HiddenAsserts = new ArrayList<>(t2HiddenFailureMessages.values());
+            List<String> t2FailedHiddenTests = TestFinder.extractTestMethods(t2HiddenTestNames, "HIDDEN");
+            List<String> t3HiddenTestNames = new ArrayList<>(t3HiddenFailureMessages.keySet());
+            List<String> t3HiddenAsserts = new ArrayList<>(t3HiddenFailureMessages.values());
+            List<String> t3FailedHiddenTests = TestFinder.extractTestMethods(t3HiddenTestNames, "HIDDEN");
 
             testingResults = new TestResultAnalyzer(true, numPassedProvidedTests, numPassedHiddenTests, totalProvided, totalHidden, "", new ArrayList<>(), new ArrayList<>());
+            FailureFileWriter.writeFailuresToFile(t1FailedProvidedTests, t1FailedHiddenTests, t1ProvidedAsserts, t1HiddenAsserts, "T1");
+            FailureFileWriter.writeFailuresToFile(t2FailedProvidedTests, t2FailedHiddenTests, t2ProvidedAsserts, t2HiddenAsserts, "T2");
+            FailureFileWriter.writeFailuresToFile(t3FailedProvidedTests, t3FailedHiddenTests, t3ProvidedAsserts, t3HiddenAsserts, "T3");
 
         } else {
             System.out.println("Build Failed");

--- a/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
+++ b/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class ShellScriptRunner {
     public static void main(String[] args) {
         // Hard Coded Student Repo
-        String repo = "../repos_output/assignment-1-repository-4";
+        String repo = "../repos_output/assignment-1-repository-12";
         runTesting(repo);
     }
 
@@ -33,11 +33,14 @@ public class ShellScriptRunner {
             int numPassedProvidedTests = totalProvided - failures - errors - skipped;
 
             // Getting failed provided tests
-            Map<String, String> providedFailureMessages = TestResultAnalyzer.extractFailedTestDetails(xmlPath);
-            List<String> providedTestNames = new ArrayList<>(providedFailureMessages.keySet());
-            List<String> providedAsserts = new ArrayList<>(providedFailureMessages.values());
-            List<String> failedProvidedTests = TestFinder.extractTestMethods(providedTestNames, "PROVIDED");
-            FailureFileWriter.writeFailuresToFile(failedProvidedTests, providedAsserts, "PROVIDED");
+            List<Map<String, String>> providedFailureMessages = TestResultAnalyzer.extractFailedTestDetails(xmlPath);
+            Map<String, String> t1ProvidedFailureMessages = providedFailureMessages.get(0);
+            Map<String, String> t2ProvidedFailureMessages = providedFailureMessages.get(1);
+            Map<String, String> t3ProvidedFailureMessages = providedFailureMessages.get(2);
+//            List<String> providedTestNames = new ArrayList<>(providedFailureMessages.keySet());
+//            List<String> providedAsserts = new ArrayList<>(providedFailureMessages.values());
+//            List<String> failedProvidedTests = TestFinder.extractTestMethods(providedTestNames, "PROVIDED");
+//            FailureFileWriter.writeFailuresToFile(failedProvidedTests, providedAsserts, "PROVIDED");
 
             // Running Hidden Tests
             runCommand(repositoryDirectory, "CLEAR_TESTS");
@@ -52,13 +55,16 @@ public class ShellScriptRunner {
             int numPassedHiddenTests = totalHidden - failures - errors - skipped;
 
             // Getting failed hidden tests
-            Map<String, String> hiddenFailureMessages = TestResultAnalyzer.extractFailedTestDetails(xmlPath);
-            List<String> hiddenTestNames = new ArrayList<>(hiddenFailureMessages.keySet());
-            List<String> hiddenAsserts = new ArrayList<>(hiddenFailureMessages.values());
-            List<String> failedHiddenTests = TestFinder.extractTestMethods(hiddenTestNames, "HIDDEN");
-            FailureFileWriter.writeFailuresToFile(failedHiddenTests, hiddenAsserts, "HIDDEN");
+            List<Map<String, String>> hiddenFailureMessages = TestResultAnalyzer.extractFailedTestDetails(xmlPath);
+            Map<String, String> t1HiddenFailureMessages = hiddenFailureMessages.get(0);
+            Map<String, String> t2HiddenFailureMessages = hiddenFailureMessages.get(1);
+            Map<String, String> t3HiddenFailureMessages = hiddenFailureMessages.get(2);
+//            List<String> hiddenTestNames = new ArrayList<>(hiddenFailureMessages.keySet());
+//            List<String> hiddenAsserts = new ArrayList<>(hiddenFailureMessages.values());
+//            List<String> failedHiddenTests = TestFinder.extractTestMethods(hiddenTestNames, "HIDDEN");
+//            FailureFileWriter.writeFailuresToFile(failedHiddenTests, hiddenAsserts, "HIDDEN");
 
-            testingResults = new TestResultAnalyzer(true, numPassedProvidedTests, numPassedHiddenTests, totalProvided, totalHidden, "", providedTestNames, hiddenTestNames);
+            testingResults = new TestResultAnalyzer(true, numPassedProvidedTests, numPassedHiddenTests, totalProvided, totalHidden, "", new ArrayList<>(), new ArrayList<>());
 
         } else {
             System.out.println("Build Failed");

--- a/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
+++ b/LLM Testing/Code-Testing/src/main/java/ShellScriptRunner.java
@@ -38,6 +38,7 @@ public class ShellScriptRunner {
             Map<String, String> t2ProvidedFailureMessages = providedFailureMessages.get(1);
             Map<String, String> t3ProvidedFailureMessages = providedFailureMessages.get(2);
 
+            // Collecting provided test names, assertion messages, and test methods for each task
             List<String> t1ProvidedTestNames = new ArrayList<>(t1ProvidedFailureMessages.keySet());
             List<String> t1ProvidedAsserts = new ArrayList<>(t1ProvidedFailureMessages.values());
             List<String> t1FailedProvidedTests = TestFinder.extractTestMethods(t1ProvidedTestNames, "PROVIDED");
@@ -66,6 +67,7 @@ public class ShellScriptRunner {
             Map<String, String> t2HiddenFailureMessages = hiddenFailureMessages.get(1);
             Map<String, String> t3HiddenFailureMessages = hiddenFailureMessages.get(2);
 
+            // Collecting hidden test names, assertion messages, and test methods for each task
             List<String> t1HiddenTestNames = new ArrayList<>(t1HiddenFailureMessages.keySet());
             List<String> t1HiddenAsserts = new ArrayList<>(t1HiddenFailureMessages.values());
             List<String> t1FailedHiddenTests = TestFinder.extractTestMethods(t1HiddenTestNames, "HIDDEN");
@@ -76,17 +78,21 @@ public class ShellScriptRunner {
             List<String> t3HiddenAsserts = new ArrayList<>(t3HiddenFailureMessages.values());
             List<String> t3FailedHiddenTests = TestFinder.extractTestMethods(t3HiddenTestNames, "HIDDEN");
 
-            testingResults = new TestResultAnalyzer(true, numPassedProvidedTests, numPassedHiddenTests, totalProvided, totalHidden, "", new ArrayList<>(), new ArrayList<>());
             FailureFileWriter.writeFailuresToFile(t1FailedProvidedTests, t1FailedHiddenTests, t1ProvidedAsserts, t1HiddenAsserts, "T1");
             FailureFileWriter.writeFailuresToFile(t2FailedProvidedTests, t2FailedHiddenTests, t2ProvidedAsserts, t2HiddenAsserts, "T2");
             FailureFileWriter.writeFailuresToFile(t3FailedProvidedTests, t3FailedHiddenTests, t3ProvidedAsserts, t3HiddenAsserts, "T3");
+
+            // Write results to spreadsheet
+            testingResults = new TestResultAnalyzer(true, numPassedProvidedTests, numPassedHiddenTests, totalProvided, totalHidden, "", new ArrayList<>(), new ArrayList<>());
 
         } else {
             System.out.println("Build Failed");
             System.out.println(compileResponse);
             String errorMessages = TestResultAnalyzer.getCompilationErrors(compileResponse);
-            testingResults = new TestResultAnalyzer(false, -1, -1, -1, -1, errorMessages, new ArrayList<>(), new ArrayList<>());
             ErrorFileWriter.writeErrorsToFile(errorMessages);
+            
+            // Write results to spreadsheet
+            testingResults = new TestResultAnalyzer(false, -1, -1, -1, -1, errorMessages, new ArrayList<>(), new ArrayList<>());
         }
     }
 

--- a/LLM Testing/Code-Testing/src/main/java/TestResultAnalyzer.java
+++ b/LLM Testing/Code-Testing/src/main/java/TestResultAnalyzer.java
@@ -79,8 +79,11 @@ public class TestResultAnalyzer {
     }
 
 
-    public static Map<String, String> extractFailedTestDetails(String xmlFilePath) {
-        Map<String, String> failedTestDetails = new LinkedHashMap<>();
+    public static List<Map<String, String>> extractFailedTestDetails(String xmlFilePath) {
+        List<Map<String, String>> taskTestDetails = new ArrayList<>();
+        taskTestDetails.add(new LinkedHashMap<>()); // Task 1 test cases
+        taskTestDetails.add(new LinkedHashMap<>()); // Task 2 test cases
+        taskTestDetails.add(new LinkedHashMap<>()); // Task 3 test cases
 
         try {
             File file = new File(xmlFilePath);
@@ -100,14 +103,20 @@ public class TestResultAnalyzer {
                             .item(0)
                             .getTextContent();
 
-                    failedTestDetails.put(testName, assertionMessage);
+                    if (testName.startsWith("T1")) {
+                        taskTestDetails.get(0).put(testName, assertionMessage);
+                    } else if (testName.startsWith("T2")) {
+                        taskTestDetails.get(1).put(testName, assertionMessage);
+                    } else if (testName.startsWith("T3")) {
+                        taskTestDetails.get(2).put(testName, assertionMessage);
+                    }
                 }
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        return failedTestDetails;
+        return taskTestDetails;
     }
 
 }

--- a/LLM Testing/Tests/MainTestHidden.java
+++ b/LLM Testing/Tests/MainTestHidden.java
@@ -13,7 +13,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
   MainTest.Task1.class, //
   MainTest.Task2.class, // Uncomment this line when to start Task 2
-  // MainTest.Task3.class, // Uncomment this line when to start Task 3
+   MainTest.Task3.class, // Uncomment this line when to start Task 3
   // MainTest.YourTests.class, // Uncomment this line to run your own tests
 })
 public class MainTest {


### PR DESCRIPTION
- extract failed test information into separate tasks
- writing failure files for each task that contains both provided and hidden tests